### PR TITLE
Allow multiple QR code instances 

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -203,37 +203,38 @@ var QRCode;
 		 * @param {Function} fFail Occurs if it doesn't support Data URI
 		 */
 		function _safeSetDataURI(fSuccess, fFail) {
-			this._fFail = fFail;
-			this._fSuccess = fSuccess;
-	
-			// Check it just once
-			if (this._bSupportDataURI === null) {
-				var el = document.createElement("img");
-				var fOnError = function () {
-					this._bSupportDataURI = false;
-					
-					if (this._fFail) {
-						_fFail.call(this);	
-					}					
-				};
-				var fOnSuccess = function () {
-					this._bSupportDataURI = true;
-					
-					if (this._fSuccess) {
-						_fSuccess.call(this);
-					}
-				};
-				
-				el.onabort = fOnError;
-				el.onerror = fOnError;
-				el.onload = fOnSuccess;
-				el.src = "data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="; // the Image contains 1px data.
-				return;
-			} else if (this._bSupportDataURI === true && this._fSuccess) {
-				_fSuccess.call(this);
-			} else if (this._bSupportDataURI === false && this._fFail) {
-				_fFail.call(this);
-			}
+            var self = this;
+            self._fFail = fFail;
+            self._fSuccess = fSuccess;
+
+            // Check it just once
+            if (self._bSupportDataURI === null) {
+                var el = document.createElement("img");
+                var fOnError = function() {
+                    self._bSupportDataURI = false;
+
+                    if (self._fFail) {
+                        _fFail.call(self);
+                    }
+                };
+                var fOnSuccess = function() {
+                    self._bSupportDataURI = true;
+
+                    if (self._fSuccess) {
+                        self._fSuccess.call(self);
+                    }
+                };
+
+                el.onabort = fOnError;
+                el.onerror = fOnError;
+                el.onload = fOnSuccess;
+                el.src = "data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="; // the Image contains 1px data.
+                return;
+            } else if (self._bSupportDataURI === true && self._fSuccess) {
+                self._fSuccess.call(self);
+            } else if (self._bSupportDataURI === false && self._fFail) {
+                self._fFail.call(self);
+            }
 		};
 		
 		/**


### PR DESCRIPTION
Fixes #2

Previously, private variables were trapped by the outer function
closure that returns the Drawing constructor.

I removed these declarations and scoped them to the object instance.
This has the side affect of making them public.  If that is
undesirable, the code can be refactored further to keep these private.

I haven't fully tested all codepaths (table based drawing, android
specific logic), so more regression should probably be done before
merging this in to your codebase.
