### PR TITLE
Fixed syntax error in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "homepage": "https://github.com/davidshimjs/qrcodejs",
   "authors": [
-    "Sangmin Shim", "Sangmin Shim <ssm0123@gmail.com> (http://jaguarjs.com)",
+    "Sangmin Shim", "Sangmin Shim <ssm0123@gmail.com> (http://jaguarjs.com)"
   ],
   "description": "Cross-browser QRCode generator for javascript",
   "main": "qrcode.js",
@@ -13,7 +13,7 @@
     "index.html",
     "index.svg",
     "jquery.min.js",
-    "qrcode.min.js",
+    "qrcode.min.js"
   ],
   "dependencies": {
     "jquery": ">=1.8.3"


### PR DESCRIPTION
`bower.json` has syntax error and bower can't install qrcode.js.

```sh
$ bower install qrcode.js=https://github.com/davidshimjs/qrcodejs.git
bower qrcode.js#*           not-cached https://github.com/davidshimjs/qrcodejs.git#*
bower qrcode.js#*              resolve https://github.com/davidshimjs/qrcodejs.git#*
bower qrcode.js#*             checkout master
bower qrcode.js#*           EMALFORMED Failed to read /var/folders/s2/j1hmfp3s2814bqll10pjny180000gn/T/hanai/bower/qrcode.js-6803-fUODrr/bower.json

Additional error details:
Unexpected token ]
```