### PR TITLE
Fix syntax error in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "homepage": "https://github.com/davidshimjs/qrcodejs",
   "authors": [
-    "Sangmin Shim", "Sangmin Shim <ssm0123@gmail.com> (http://jaguarjs.com)",
+    "Sangmin Shim", "Sangmin Shim <ssm0123@gmail.com> (http://jaguarjs.com)"
   ],
   "description": "Cross-browser QRCode generator for javascript",
   "main": "qrcode.js",


### PR DESCRIPTION
This trailing comma causes bower install to fail. It's legal in Javascript but not JSON.
