### PR TITLE
Remove unneeded jquery dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,8 +14,5 @@
     "index.svg",
     "jquery.min.js",
     "qrcode.min.js"
-  ],
-  "dependencies": {
-    "jquery": ">=1.8.3"
-  }
+  ]
 }


### PR DESCRIPTION
This fix removes unneeded dependency of jQuery
It is a redundant dependency because in `qrcode.js` there is no any calls to `jQuery` library. There are calls to `jQuery` in `html` examples but this is not a concern of `bower.json`. This file used only for library dependence resolving.