### PR TITLE
Added quiet zone / border option

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -195,12 +195,12 @@ var QRCode;
 				return el;
 			}
 
-			var svg = makeSVG("svg" , {'viewBox': '0 0 ' + String(nCount) + " " + String(nCount), 'width': '100%', 'height': '100%', 'fill': _htOption.colorLight});
+			var svg = makeSVG("svg" , {'viewBox': '0 0 ' + String(nCount + 2 * _htOption.border) + " " + String(nCount + 2 * _htOption.border), 'width': '100%', 'height': '100%', 'fill': _htOption.colorLight});
 			svg.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:xlink", "http://www.w3.org/1999/xlink");
 			_el.appendChild(svg);
 
 			svg.appendChild(makeSVG("rect", {"fill": _htOption.colorLight, "width": "100%", "height": "100%"}));
-			svg.appendChild(makeSVG("rect", {"fill": _htOption.colorDark, "width": "1", "height": "1", "id": "template"}));
+			svg.appendChild(makeSVG("rect", {"fill": _htOption.colorDark, "x": String(_htOption.border), "y": String(_htOption.border), "width": "1", "height": "1", "id": "template"}));
 
 			for (var row = 0; row < nCount; row++) {
 				for (var col = 0; col < nCount; col++) {
@@ -222,7 +222,8 @@ var QRCode;
 	var useSVG = document.documentElement.tagName.toLowerCase() === "svg";
 
 	// Drawing in DOM by using Table tag
-	var Drawing = useSVG ? svgDrawer : !_isSupportCanvas() ? (function () {
+	//var Drawing = useSVG ? svgDrawer : !_isSupportCanvas() ? (function () {
+	var Drawing = useSVG ? svgDrawer : true ? (function () {
 		var Drawing = function (el, htOption) {
 			this._el = el;
 			this._htOption = htOption;
@@ -241,16 +242,45 @@ var QRCode;
 			var nHeight = Math.floor(_htOption.height / nCount);
 			var aHTML = ['<table style="border:0;border-collapse:collapse;">'];
 			
+			for (var row = 0; row < _htOption.border; row++) {
+				aHTML.push('<tr>');
+				
+				for (var col = 0; col < nCount + 2 * _htOption.border; col++) {
+					aHTML.push('<td style="border:0;border-collapse:collapse;padding:0;margin:0;width:' + nWidth + 'px;height:' + nHeight + 'px;background-color:' + _htOption.colorLight + ';"></td>');
+				}
+				
+				aHTML.push('</tr>');
+			}
+
+			
 			for (var row = 0; row < nCount; row++) {
 				aHTML.push('<tr>');
+				
+				for (var col = 0; col < _htOption.border; col++) {
+					aHTML.push('<td style="border:0;border-collapse:collapse;padding:0;margin:0;width:' + nWidth + 'px;height:' + nHeight + 'px;background-color:' + _htOption.colorLight + ';"></td>');
+				}
 				
 				for (var col = 0; col < nCount; col++) {
 					aHTML.push('<td style="border:0;border-collapse:collapse;padding:0;margin:0;width:' + nWidth + 'px;height:' + nHeight + 'px;background-color:' + (oQRCode.isDark(row, col) ? _htOption.colorDark : _htOption.colorLight) + ';"></td>');
 				}
 				
+				for (var col = 0; col < _htOption.border; col++) {
+					aHTML.push('<td style="border:0;border-collapse:collapse;padding:0;margin:0;width:' + nWidth + 'px;height:' + nHeight + 'px;background-color:' + _htOption.colorLight + ';"></td>');
+				}
+				
 				aHTML.push('</tr>');
 			}
 			
+			for (var row = 0; row < _htOption.border; row++) {
+				aHTML.push('<tr>');
+				
+				for (var col = 0; col < nCount + 2 * _htOption.border; col++) {
+					aHTML.push('<td style="border:0;border-collapse:collapse;padding:0;margin:0;width:' + nWidth + 'px;height:' + nHeight + 'px;background-color:' + _htOption.colorLight + ';"></td>');
+				}
+				
+				aHTML.push('</tr>');
+			}
+
 			aHTML.push('</table>');
 			_el.innerHTML = aHTML.join('');
 			
@@ -379,14 +409,25 @@ var QRCode;
             var _htOption = this._htOption;
             
 			var nCount = oQRCode.getModuleCount();
-			var nWidth = _htOption.width / nCount;
-			var nHeight = _htOption.height / nCount;
+			var nWidth = _htOption.width / (nCount + 2 * _htOption.border);
+			var nHeight = _htOption.height / (nCount + 2 * _htOption.border);
+			var nBorderWidth = _htOption.border * nWidth;
+			var nBorderHeight = _htOption.border * nHeight;
 			var nRoundedWidth = Math.round(nWidth);
 			var nRoundedHeight = Math.round(nHeight);
 
 			_elImage.style.display = "none";
 			this.clear();
 			
+            // Fill quiet zone with light color
+            _oContext.strokeStyle = _htOption.colorLight;
+            _oContext.lineWidth = 1;
+            _oContext.fillStyle = _htOption.colorLight;					
+            _oContext.fillRect(0, 0, _htOption.width, nBorderHeight);
+            _oContext.fillRect(0, _htOption.height - nBorderHeight, _htOption.width, _htOption.height);
+            _oContext.fillRect(0, nBorderHeight, nBorderWidth, _htOption.height - nBorderHeight);
+            _oContext.fillRect(_htOption.width - nBorderWidth, nBorderHeight, _htOption.width, _htOption.height - nBorderHeight);
+
 			for (var row = 0; row < nCount; row++) {
 				for (var col = 0; col < nCount; col++) {
 					var bIsDark = oQRCode.isDark(row, col);
@@ -395,19 +436,19 @@ var QRCode;
 					_oContext.strokeStyle = bIsDark ? _htOption.colorDark : _htOption.colorLight;
 					_oContext.lineWidth = 1;
 					_oContext.fillStyle = bIsDark ? _htOption.colorDark : _htOption.colorLight;					
-					_oContext.fillRect(nLeft, nTop, nWidth, nHeight);
+					_oContext.fillRect(nLeft + nBorderWidth, nTop + nBorderHeight, nWidth, nHeight);
 					
 					// 안티 앨리어싱 방지 처리
 					_oContext.strokeRect(
-						Math.floor(nLeft) + 0.5,
-						Math.floor(nTop) + 0.5,
+						Math.floor(nLeft + nBorderWidth) + 0.5,
+						Math.floor(nTop + nBorderHeight) + 0.5,
 						nRoundedWidth,
 						nRoundedHeight
 					);
 					
 					_oContext.strokeRect(
-						Math.ceil(nLeft) - 0.5,
-						Math.ceil(nTop) - 0.5,
+						Math.ceil(nLeft + nBorderWidth) - 0.5,
+						Math.ceil(nTop + nBorderHeight) - 0.5,
 						nRoundedWidth,
 						nRoundedHeight
 					);
@@ -528,6 +569,7 @@ var QRCode;
 	 * @param {String} vOption.text QRCode link data
 	 * @param {Number} [vOption.width=256]
 	 * @param {Number} [vOption.height=256]
+	 * @param {Number} [vOption.border=4] default to 4 modules
 	 * @param {String} [vOption.colorDark="#000000"]
 	 * @param {String} [vOption.colorLight="#ffffff"]
 	 * @param {QRCode.CorrectLevel} [vOption.correctLevel=QRCode.CorrectLevel.H] [L|M|Q|H] 
@@ -536,6 +578,7 @@ var QRCode;
 		this._htOption = {
 			width : 256, 
 			height : 256,
+			border: 4,
 			typeNumber : 4,
 			colorDark : "#000000",
 			colorLight : "#ffffff",

--- a/qrcode.js
+++ b/qrcode.js
@@ -222,8 +222,7 @@ var QRCode;
 	var useSVG = document.documentElement.tagName.toLowerCase() === "svg";
 
 	// Drawing in DOM by using Table tag
-	//var Drawing = useSVG ? svgDrawer : !_isSupportCanvas() ? (function () {
-	var Drawing = useSVG ? svgDrawer : true ? (function () {
+	var Drawing = useSVG ? svgDrawer : !_isSupportCanvas() ? (function () {
 		var Drawing = function (el, htOption) {
 			this._el = el;
 			this._htOption = htOption;


### PR DESCRIPTION
Added quiet zone / border option. I understand that you can use css margin as stated in issue #21, but when you save the QR code as an image, there's no border. This can cause the QR code not recognizable. I reproduced the issue when saving the image on the cellphone.

I set the default border size to 4 module according to ISO/IEC 18004 standard. 
