### PR TITLE
fixed broken script link

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ qrcode.makeCode("http://naver.com"); // make another code.
 <h2>Sample Code</h2>
 
 <pre class="codepen" data-height="350" data-type="result" data-href="rJgjv" data-user="davidshimjs" data-safe="true"><code></code></pre>
-<script async src="http://codepen.io/assets/embed/ei.js"></script>
+<script async src="https://codepen.io/assets/embed/ei.js"></script>
 
 <h2>Browser Compatibility</h2>
 


### PR DESCRIPTION
The current demo doesn't work at https://davidshimjs.github.io/qrcodejs/ because there is a broken link to the codepen.io javascript.

http:// -> https:// fixes broken link to https://codepen.io/assets/embed/ei.js