### PR TITLE
Minor bug with QR code type length for long input strings

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -470,7 +470,7 @@ var QRCode;
 		var nType = 1;
 		var length = _getUTF8Length(sText);
 		
-		for (var i = 0, len = QRCodeLimitLength.length; i <= len; i++) {
+		for (var i = 0, len = QRCodeLimitLength.length; i < len; i++) {
 			var nLimit = 0;
 			
 			switch (nCorrectLevel) {


### PR DESCRIPTION
Less than or equal to vs less than