### PR TITLE
Do not set title attribute

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -582,7 +582,6 @@ var QRCode;
 		this._oQRCode = new QRCodeModel(_getTypeNumber(sText, this._htOption.correctLevel), this._htOption.correctLevel);
 		this._oQRCode.addData(sText);
 		this._oQRCode.make();
-		this._el.title = sText;
 		this._oDrawing.draw(this._oQRCode);			
 		this.makeImage();
 	};


### PR DESCRIPTION
When a mouse is over the rendered image, title causes a tooltip to show.
If the tooltip is placed so that it disrupts a sync marker, the code cannot
be read from the screen.

Title should be set by the library used if needed.