### PR TITLE
Better way to get android version

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -162,7 +162,7 @@ var QRCode;
 		
 		if (/android/i.test(sAgent)) { // android
 			android = true;
-			var aMat = sAgent.toString().match(/android ([0-9]\.[0-9])/i);
+			var aMat = sAgent.toString().match(/android ([0-9]+(\.[0-9]+)?)/i);
 			
 			if (aMat && aMat[1]) {
 				android = parseFloat(aMat[1]);


### PR DESCRIPTION
1. Support `Android 9` (not `Android 9.0`)
2. Support `Android 10.10`

User agent sample: `Mozilla/5.0 (Linux; U; Android 9; zh-cn; MIX 2S Build/PKQ1.180729.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.1.2`