### PR TITLE
QRCodeLimitLength. Fixed length check on for loop.

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -470,7 +470,7 @@ var QRCode;
 		var nType = 1;
 		var length = _getUTF8Length(sText);
 		
-		for (var i = 0, len = QRCodeLimitLength.length; i <= len; i++) {
+		for (var i = 0, len = QRCodeLimitLength.length; i < len; i++) {
 			var nLimit = 0;
 			
 			switch (nCorrectLevel) {


### PR DESCRIPTION
**Steps:**
* Try to generate a QR code with a string that's too big.

Check this jsfiddle: https://jsfiddle.net/Alfro/21pjuy4q/2/

**Expected Result:**
The function throws an error: "Error: Too long data"

**Actual Result:**
TypeError: QRCodeLimitLength[i] is undefined