### PR TITLE
Solved multiple canvas issue

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -357,6 +357,7 @@ var QRCode;
 			this._elCanvas = document.createElement("canvas");
 			this._elCanvas.width = htOption.width;
 			this._elCanvas.height = htOption.height;
+			el.innerHTML = "";
 			el.appendChild(this._elCanvas);
 			this._el = el;
 			this._oContext = this._elCanvas.getContext("2d");


### PR DESCRIPTION
If el is already populate, it makes duplicate childs that can't fit in original geometry.
I added row 360 with this code to avoid the bug.
el.innerHTML = "";

Scenario for multiple canvas issue on Codepen
https://codepen.io/tonywhite1985/pen/bGgedMN?editors=1000

Try to comment this in JS tab on row 918
el.innerHTML = "";
and see glithes.

1) Open RESULT tab and start typing some text to encode 
2) Detele all text
3) Try to type another text to encode
4) See qrcode (it shows badly when el.innerHTML = ""; is under comment)