### PR TITLE
fix: Android test RegExp can't match Android 10 or 10.1 and so on

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -162,7 +162,7 @@ var QRCode;
 		
 		if (/android/i.test(sAgent)) { // android
 			android = true;
-			var aMat = sAgent.toString().match(/android ([0-9]\.[0-9])/i);
+			var aMat = sAgent.toString().match(/android (([0-9])+(\.[0-9]+)?)/i);
 			
 			if (aMat && aMat[1]) {
 				android = parseFloat(aMat[1]);


### PR DESCRIPTION
I found the bug on Huawei mate30 which userAgent is "... Android 10 ...", Qrcode.js can not get the correct android version on the device because of the reg.

I fixed it and checked it, there are test cases:
```
const TEST_CASE = [
    {source: 'android 0', expect: 0},
    {source: 'android 0.1', expect: 0.1},
    {source: 'android 0.1.1', expect: 0.1},
    {source: 'android 10', expect: 10},
    {source: 'android 10.0', expect: 10},
    {source: 'android 11.1', expect: 11.1},
    {source: 'android 11.09.1', expect: 11.09},
    {source: 'android 111.1.1', expect: 111.1}
]

const test = (reg) => {
    return TEST_CASE.every(item => {
        return Number.parseFloat(item.source.match(reg)[1]) === item.expect;
    })
}

test(/android (([0-9])+(\.[0-9]+)?)/i);   // true
```
Could you please approve it, I think the Qrcode.js is very usefull, Thank you guys~