### PR TITLE
correct support of unicode texts #266 #236

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -32,20 +32,22 @@ var QRCode;
 		this.parsedData = [];
 
 		// Added to support UTF-8 Characters
+		var getCode = data.codePointAt || data.charCodeAt;		// IE <= 11 doesn't has codePointAt
 		for (var i = 0, l = this.data.length; i < l; i++) {
 			var byteArray = [];
-			var code = this.data.charCodeAt(i);
+			var code = getCode.call(data, i);
 
-			if (code > 0x10000) {
+			if (code >= 0x10000) {
 				byteArray[0] = 0xF0 | ((code & 0x1C0000) >>> 18);
 				byteArray[1] = 0x80 | ((code & 0x3F000) >>> 12);
 				byteArray[2] = 0x80 | ((code & 0xFC0) >>> 6);
 				byteArray[3] = 0x80 | (code & 0x3F);
-			} else if (code > 0x800) {
+				i++;
+			} else if (code >= 0x800) {
 				byteArray[0] = 0xE0 | ((code & 0xF000) >>> 12);
 				byteArray[1] = 0x80 | ((code & 0xFC0) >>> 6);
 				byteArray[2] = 0x80 | (code & 0x3F);
-			} else if (code > 0x80) {
+			} else if (code >= 0x80) {
 				byteArray[0] = 0xC0 | ((code & 0x7C0) >>> 6);
 				byteArray[1] = 0x80 | (code & 0x3F);
 			} else {


### PR DESCRIPTION
One can easily test, that library draws wrong QR-codes for some special inputs like
new QRCode(elem "\x80");
new QRCode(elem, "\u0800"); // samaritan letter alaf
or any string, conatining chars with codes greater than 0xFFFF
new QRCode(elem, "🔥");

The reasons are 
- minor bounds check mistakes 
- string method charCodeAt never returns codes greater than 0xFFFF, so one of the branches of QR8bitByte is never used!

One should notice, that js support for unicode strings is pretty poor: 
"🔥".length === 2, even though every human would say, this string has one 'character'.

P.S. qrcode.min.js  should be updated also, i suppose, but i'm not sure which settings should be used, except smth like "preserve ie 6 compatibility" 