### PR TITLE
Added CDN Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ QRCode.js is javascript library for making QRCode. QRCode.js supports Cross-brow
 QRCode.js has no dependencies.
 
 ## Basic Usages
+
+CDN link:
+```
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js" integrity="sha512-CNgIRecGo7nphbeZ04Sc13ka07paqdeTu0WR1IM4kNcpmBAUSHSQX0FslNhTDadL4O5SAGapGt4FodqL8My0mA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
+```
+
 ```
 <div id="qrcode"></div>
 <script type="text/javascript">


### PR DESCRIPTION
In the readme file, there is no CDN script to use it in the code. I have provided the CDN script so that developers can directly  copy and paste it from the readme.