### PR TITLE
Adding possibility to use qr tags

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -611,4 +611,30 @@ var QRCode;
 	 * @name QRCode.CorrectLevel
 	 */
 	QRCode.CorrectLevel = QRErrorCorrectLevel;
+
+	let qrdinamic = document.getElementsByTagName("qr")
+
+    if (qrdinamic) {
+
+    let qrda = Array.from(qrdinamic);
+
+    qrda.forEach((element) => {
+        let width = element.getAttribute("width") || "220px";
+        let height = element.getAttribute("height") || (width || "220px");
+        let colorDark = element.getAttribute("colorDark") || "#000000";
+        let colorLight = element.getAttribute("colorLight") || "#ffffff";
+        let content = element.getAttribute("content") || null;
+
+        if (content) {
+            var qrcode = new QRCode(element, {
+                text: content,
+                width: parseInt(width),
+                height: parseInt(height),
+                colorDark : colorDark,
+                colorLight : colorLight
+            });
+        }
+        
+      });
+    }
 })();


### PR DESCRIPTION
To use it like a qr tag, if there is no qr tag it will work as usual.

Example:

`<qr width="300" content="http://getloom.vercel.app" colorDark="#2670F4" colorLight="white"></qr>`
