### PR TITLE
Test for document

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -219,7 +219,7 @@ var QRCode;
 		return Drawing;
 	})();
 
-	var useSVG = document.documentElement.tagName.toLowerCase() === "svg";
+	var useSVG = global.document && document.documentElement.tagName.toLowerCase() === "svg";
 
 	// Drawing in DOM by using Table tag
 	var Drawing = useSVG ? svgDrawer : !_isSupportCanvas() ? (function () {


### PR DESCRIPTION
If rendering on Node, document is undefined which throws an error.  This checks that the document object exists before trying to call documentElement, which prevents the error.